### PR TITLE
Newer vrsion of numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exact_cover"
-version = "0.4.2"
+version = "0.4.3"
 description = "Solve exact cover problems"
 readme = "README.md"
 authors = ["Moy Easwaran"]
@@ -15,7 +15,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.7.1"
-numpy = "^1.19.4"
+numpy = "^1.20"
 setuptools = "^51.1.2"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
The numpy C API has backwards compatibility broken at version 1.20. Depending on version 1.19.4 is leaving oneself hostage to fortune. Making 1.20 the requirement means that it's much less likely that the installed version of numpy and the version used to build against will be incompatible.