### PR TITLE
Fix memory leak

### DIFF
--- a/src/exact_cover.c
+++ b/src/exact_cover.c
@@ -33,16 +33,11 @@ static PyObject* get_exact_cover(PyObject* self, PyObject* args)
 {
 
     PyArrayObject *in_array;
-    PyObject      *out_array;
     npy_intp      *dims;
     int           *in_array_data, rows, cols, result;
 
     /*  Parse single numpy array argument */
     if (!PyArg_ParseTuple(args, "O!", &PyArray_Type, &in_array)) return NULL;
-
-    /*  Construct the output array, like the input array */
-    out_array = PyArray_NewLikeArray(in_array, NPY_ANYORDER, NULL, 0);
-    if (out_array == NULL) return NULL;
 
     /*  Check that we got a 2-dimensional array of dtype='int32'. */
     if (not_2d_int_array(in_array)) return NULL;
@@ -59,7 +54,8 @@ static PyObject* get_exact_cover(PyObject* self, PyObject* args)
     dims = malloc(nd * sizeof(*dims));
     dims[0] = result;
     PyObject *return_solution = PyArray_SimpleNewFromData(nd, dims, NPY_INT32, (void*)solution);
-    Py_INCREF(return_solution);
+    PyArray_ENABLEFLAGS((PyArrayObject*) return_solution, NPY_ARRAY_OWNDATA);
+    free(dims);
     return return_solution;
 }
 


### PR DESCRIPTION
I've had a go at fixing the memory leak I mentioned (https://github.com/jwg4/exact_cover/issues/52). There seems to be a couple of issues. There's an array called `out_array` that gets created but never assigned to, so I removed it completely. There was a malloc of `dims` that was never freed so I freed it. And there seem to be an extra reference to return_solution which I fixed by flagging `NPY_ARRAY_OWNDATA`. The tests still pass.