### PR TITLE
Change input type to boolean numpy array

### DIFF
--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, 'nodeploy')"

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, 'nodeploy')"

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, 'nodeploy')"

--- a/.github/workflows/poetry-quick-test.yml
+++ b/.github/workflows/poetry-quick-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/poetry-quick-test.yml
+++ b/.github/workflows/poetry-quick-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/poetry-quick-test.yml
+++ b/.github/workflows/poetry-quick-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/poetry-test.yml
+++ b/.github/workflows/poetry-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/poetry-test.yml
+++ b/.github/workflows/poetry-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/poetry-test.yml
+++ b/.github/workflows/poetry-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Now we can call `exact_cover`:
 
     >>> import numpy as np
     >>> import exact_cover as ec
-    >>> S = np.array([[1,0,0,1,0],[1,1,1,0,0],[0,1,1,0,0],[0,0,0,0,1]], dtype=np.bool_)
+    >>> S = np.array([[1,0,0,1,0],[1,1,1,0,0],[0,1,1,0,0],[0,0,0,0,1]], dtype=bool)
     >>> ec.get_exact_cover(S)
     array([0, 2, 3])
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Now we can call `exact_cover`:
 
     >>> import numpy as np
     >>> import exact_cover as ec
-    >>> S = np.array([[1,0,0,1,0],[1,1,1,0,0],[0,1,1,0,0],[0,0,0,0,1]], dtype=np.int32)
+    >>> S = np.array([[1,0,0,1,0],[1,1,1,0,0],[0,1,1,0,0],[0,0,0,0,1]], dtype=np.bool_)
     >>> ec.get_exact_cover(S)
     array([0, 2, 3])
 

--- a/exact_cover/helpers.py
+++ b/exact_cover/helpers.py
@@ -5,7 +5,7 @@ from collections import deque
 import numpy as np
 
 from .error import NoSolution, CannotSplitFurther
-
+from .io import DTYPE_FOR_ARRAY
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ def create_numpy_array(a):
     >>> create_numpy_array([[0, 1], [1, 0]])
     numpy.array([[0, 1], [1, 0]])
     """
-    return np.array(a)
+    return np.array(a, dtype=DTYPE_FOR_ARRAY)
 
 
 def split_problem(a, n):

--- a/exact_cover/io.py
+++ b/exact_cover/io.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-DTYPE_FOR_ARRAY = np.int32
+DTYPE_FOR_ARRAY = np.bool_
 
 
 def load_problem(filename):
-    return np.genfromtxt(filename, dtype=DTYPE_FOR_ARRAY)
+    return np.array(np.genfromtxt(filename), dtype=DTYPE_FOR_ARRAY)
 
 
 def save_problem(filename, array):
-    np.savetxt(filename, array)
+    np.savetxt(filename, np.array(array, dtype=np.int8))

--- a/exact_cover/wrapper.py
+++ b/exact_cover/wrapper.py
@@ -3,6 +3,7 @@ from exact_cover_impl import get_exact_cover as raw_get_exact_cover
 from .error import NoSolution
 from .io import DTYPE_FOR_ARRAY
 
+
 def get_exact_cover(matrix):
     if matrix.dtype == DTYPE_FOR_ARRAY:
         result = raw_get_exact_cover(matrix)

--- a/exact_cover/wrapper.py
+++ b/exact_cover/wrapper.py
@@ -1,10 +1,13 @@
 from exact_cover_impl import get_exact_cover as raw_get_exact_cover
 
 from .error import NoSolution
-
+from .io import DTYPE_FOR_ARRAY
 
 def get_exact_cover(matrix):
-    result = raw_get_exact_cover(matrix)
+    if matrix.dtype == DTYPE_FOR_ARRAY:
+        result = raw_get_exact_cover(matrix)
+    else:
+        result = raw_get_exact_cover(matrix.astype(DTYPE_FOR_ARRAY))
     if result.size == 0:
         raise NoSolution("No solutions found by the C code.")
     return result

--- a/src/dlx.c
+++ b/src/dlx.c
@@ -42,7 +42,7 @@ int search(list sparse_matrix, int k, int max, int *solution) {
     return result;
 }
 
-int dlx_get_exact_cover(int rows, int cols, int matrix[], int *solution) {
+int dlx_get_exact_cover(int rows, int cols, char matrix[], int *solution) {
     list sparse_matrix;
     int solution_length;
 

--- a/src/dlx.h
+++ b/src/dlx.h
@@ -5,7 +5,7 @@
 #include "sparse_matrix.h"
 
 int search(list, int, int, int *);
-int dlx_get_exact_cover(int, int, int [], int*);
+int dlx_get_exact_cover(int, int, char [], int*);
 
 #endif
 

--- a/src/exact_cover.c
+++ b/src/exact_cover.c
@@ -34,7 +34,8 @@ static PyObject* get_exact_cover(PyObject* self, PyObject* args)
 
     PyArrayObject *in_array;
     npy_intp      *dims;
-    int           *in_array_data, rows, cols, result;
+    char          *in_array_data;
+    int           rows, cols, result;
 
     /*  Parse single numpy array argument */
     if (!PyArg_ParseTuple(args, "O!", &PyArray_Type, &in_array)) return NULL;

--- a/src/exact_cover.c
+++ b/src/exact_cover.c
@@ -22,7 +22,7 @@ static bool not_2d_int_array(PyArrayObject *in_array) {
         PyErr_SetString(PyExc_ValueError, _EXACT_COVER_NP_DIM_ERROR_);
         return 1;
     }
-    if (PyArray_TYPE(in_array) != NPY_INT32) { 
+    if (PyArray_TYPE(in_array) != NPY_BOOL) { 
         PyErr_SetString(PyExc_TypeError, _EXACT_COVER_NP_TYPE_ERROR_);
         return 1;
     }
@@ -41,11 +41,11 @@ static PyObject* get_exact_cover(PyObject* self, PyObject* args)
 
     /*  Check that we got a 2-dimensional array of dtype='int32'. */
     if (not_2d_int_array(in_array)) return NULL;
-
+    
     /*  Get the data. */
     dims = PyArray_DIMS(in_array);
     rows = (int) dims[0],  cols = (int) dims[1];
-    in_array_data = (int*) PyArray_DATA(in_array);
+    in_array_data = (char*) PyArray_DATA(in_array);
 
     /*  Calculate the exact cover. */
     int nd = 1, *solution = malloc(rows * sizeof(*solution));

--- a/src/exact_cover.c
+++ b/src/exact_cover.c
@@ -10,7 +10,7 @@
 #include "dlx.h"
 
 #define _EXACT_COVER_NP_DIM_ERROR_ "get_exact_cover(...) needs a 2-dimensional (m x n) matrix."
-#define _EXACT_COVER_NP_TYPE_ERROR_ "get_exact_cover(...) needs a matrix of dtype 'int32'."
+#define _EXACT_COVER_NP_TYPE_ERROR_ "get_exact_cover(...) needs a matrix of dtype 'bool'."
 
 
 static bool not_2d_int_array(PyArrayObject *);
@@ -39,7 +39,7 @@ static PyObject* get_exact_cover(PyObject* self, PyObject* args)
     /*  Parse single numpy array argument */
     if (!PyArg_ParseTuple(args, "O!", &PyArray_Type, &in_array)) return NULL;
 
-    /*  Check that we got a 2-dimensional array of dtype='int32'. */
+    /*  Check that we got a 2-dimensional array of dtype='bool'. */
     if (not_2d_int_array(in_array)) return NULL;
     
     /*  Get the data. */

--- a/src/sparse_matrix.c
+++ b/src/sparse_matrix.c
@@ -18,7 +18,7 @@
  */
 
 
-list create_sparse (int row_count, int col_count, int matrix[]) {
+list create_sparse (int row_count, int col_count, char matrix[]) {
     list sparse_matrix = create_headers_list(col_count);
     if (not_empty(sparse_matrix))
         sparse_matrix = populate_sparse_matrix(sparse_matrix, row_count, col_count, matrix);
@@ -48,7 +48,7 @@ list create_headers_list(int col_count) {
 
 // Assumptions:
 // sparse_matrix is not NULL
-list populate_sparse_matrix(list sparse_matrix, int row_count, int col_count, int matrix[]) {
+list populate_sparse_matrix(list sparse_matrix, int row_count, int col_count, char matrix[]) {
     int row_num, col_num;
     list col, row_list;
     node_ptr new_node;

--- a/src/sparse_matrix.h
+++ b/src/sparse_matrix.h
@@ -7,9 +7,9 @@
 
 #include "quad_linked_list.h"
 
-list create_sparse (int, int, int []);
+list create_sparse (int, int, char []);
 list create_headers_list(int);
-list populate_sparse_matrix(list, int, int, int []);
+list populate_sparse_matrix(list, int, int, char []);
 list choose_column_with_min_data(list, int);
 void print_sparse_matrix_transpose(list, int);
 void print_column(list, int);

--- a/tests/test_dlx.c
+++ b/tests/test_dlx.c
@@ -9,7 +9,7 @@ test_get_one_row_result(const MunitParameter params[], void* data) {
 
   int row_count = 1;
   int col_count = 3;
-  int array[] = {1, 1, 1};
+  char array[] = {1, 1, 1};
   int solution[] = {0};
 
   int length = dlx_get_exact_cover(row_count, col_count, array, solution);
@@ -25,7 +25,7 @@ test_get_two_row_result(const MunitParameter params[], void* data) {
 
   int row_count = 2;
   int col_count = 3;
-  int array[] = {1, 0, 0, 0, 1, 1};
+  char array[] = {1, 0, 0, 0, 1, 1};
   int solution[] = {0, 0};
 
   int length = dlx_get_exact_cover(row_count, col_count, array, solution);
@@ -44,7 +44,7 @@ test_get_multiple_row_result(const MunitParameter params[], void* data) {
 
   int row_count = 4;
   int col_count = 3;
-  int array[] = {0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1};
+  char array[] = {0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1};
   int solution[] = {0, 0, 0, 0};
 
   int length = dlx_get_exact_cover(row_count, col_count, array, solution);
@@ -64,7 +64,7 @@ test_correct_zeroing_out(const MunitParameter params[], void* data) {
 
   int row_count = 4;
   int col_count = 3;
-  int array[] = {0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1};
+  char array[] = {0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1};
   int solution[] = {-1, -1, -1, -1};
 
   int length = dlx_get_exact_cover(row_count, col_count, array, solution);
@@ -84,7 +84,7 @@ test_correct_zeroing_out_2(const MunitParameter params[], void* data) {
 
   int row_count = 4;
   int col_count = 3;
-  int array[] = {0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1};
+  char array[] = {0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1};
   int solution[] = {-1, -1, -1, -1};
 
   int length = dlx_get_exact_cover(row_count, col_count, array, solution);

--- a/tests/test_exact_cover.py
+++ b/tests/test_exact_cover.py
@@ -17,6 +17,18 @@ def test_exact_cover():
     np.testing.assert_array_equal(actual, expected)
 
 
+def test_exact_cover_different_dtypes():
+    """
+    Check the exact cover routine works when input array has different dtypes
+    """
+    dtypes = [np.int32, np.int8, np.bool_]
+    for dtype in dtypes:
+        data = np.array([[1, 0, 0], [0, 1, 0], [0, 1, 1], [0, 0, 1]], dtype=dtype)
+        expected = np.array([0, 1, 3])
+        actual = get_exact_cover(data)
+        np.testing.assert_array_equal(actual, expected)
+
+
 def test_exact_cover_no_solution():
     data = np.array([[1, 0, 0], [0, 1, 0], [0, 1, 0], [0, 0, 0]], dtype=DTYPE_FOR_ARRAY)
     with pytest.raises(NoSolution):

--- a/tests/test_legacy_dlx.c
+++ b/tests/test_legacy_dlx.c
@@ -16,11 +16,11 @@ void read_csv(char filename[], int rows, int cols, char array[rows*cols]) {
     char buffer[cols*5], *ptr;
     for ( i = 0; fgets(buffer, sizeof buffer, file); ++i )
        for ( j = 0, ptr = buffer; j < cols; ++j, ++ptr )
-          array[(i*cols)+j] = (int)strtol(ptr, &ptr, 10);
+          array[(i*cols)+j] = (char)strtol(ptr, &ptr, 10);
     fclose(file);
 }
 
-void print_array(int rows, int columns, int array[rows*columns]) {
+void print_array(int rows, int columns, char array[rows*columns]) {
     int j, k;
     for (j = 0; j < rows; ++j) {
        for ( k = 0; k < columns; ++k )

--- a/tests/test_legacy_dlx.c
+++ b/tests/test_legacy_dlx.c
@@ -10,7 +10,7 @@
 #define HSIZE 324
 
 
-void read_csv(char filename[], int rows, int cols, int array[rows*cols]) {
+void read_csv(char filename[], int rows, int cols, char array[rows*cols]) {
     FILE *file = fopen(filename, "r");
     int i, j;
     char buffer[cols*5], *ptr;
@@ -31,7 +31,7 @@ void print_array(int rows, int columns, int array[rows*columns]) {
 
 static MunitResult
 test_simple_example(const MunitParameter params[], void* data) {
-    int matrix[6*7] =  // Knuth's example
+    char matrix[6*7] =  // Knuth's example
             {
               0, 0, 1, 0, 1, 1, 0,
               1, 0, 0, 1, 0, 0, 1,
@@ -55,7 +55,7 @@ test_simple_example(const MunitParameter params[], void* data) {
 static MunitResult
 test_simple_negative_example(const MunitParameter params[], void* data) {
     int *solution = malloc(VSIZE * sizeof(*solution));
-    int matrix2[6*7] =
+    char matrix2[6*7] =
             {
               1, 0, 1, 1, 1, 1, 1,
               1, 0, 0, 1, 0, 0, 1,
@@ -75,7 +75,7 @@ static MunitResult
 test_very_simple_large_example(const MunitParameter params[], void* data) {
     int result;
     int *solution = malloc(VSIZE * sizeof(*solution));
-    int matrix3[9*9] =
+    char matrix3[9*9] =
         {
           1, 0, 0, 0, 0, 0, 0, 0, 0,
           0, 1, 0, 0, 0, 0, 0, 0, 0,
@@ -99,7 +99,7 @@ test_large_example_from_csv(const MunitParameter params[], void* data) {
     int result;
     int *solution = malloc(VSIZE * sizeof(*solution));
 
-    int matrix4[64*64];
+    char matrix4[64*64];
     char filename[] = "tests/files/con4.csv";
     read_csv(filename, 64, 64, matrix4);
     result = dlx_get_exact_cover(64,64,matrix4,solution);
@@ -118,7 +118,7 @@ test_large_example_from_csv_2(const MunitParameter params[], void* data) {
     int result;
     int *solution = malloc(VSIZE * sizeof(*solution));
 
-    int matrix5[VSIZE*HSIZE];
+    char matrix5[VSIZE*HSIZE];
     char filename2[] = "tests/files/con2.csv";
     read_csv(filename2, VSIZE, HSIZE, matrix5);
     result = dlx_get_exact_cover(VSIZE,HSIZE,matrix5,solution);

--- a/tests/test_sparse_matrix.c
+++ b/tests/test_sparse_matrix.c
@@ -11,7 +11,7 @@
 
 static MunitResult test_choose_column_with_min_data(const MunitParameter params[], void* data)
 {
-    int matrix[VSIZE*HSIZE] =
+    char matrix[VSIZE*HSIZE] =
         {
  // sums: 8, 9, 8,11, 7,10, 8, 5, 5
           0, 1, 0, 1, 0, 0, 0, 1, 0,
@@ -43,7 +43,7 @@ static MunitResult test_choose_column_with_min_data(const MunitParameter params[
 
 static MunitResult test_cover_column(const MunitParameter params[], void* data)
 {
-    int matrix[VSIZE*HSIZE] =
+    char matrix[VSIZE*HSIZE] =
         {
  // sums: 8, 9, 8,11, 7,10, 8, 5, 5
           0, 1, 0, 1, 0, 0, 0, 1, 0,
@@ -79,7 +79,7 @@ static MunitResult test_cover_column(const MunitParameter params[], void* data)
 
 static MunitResult test_cover_and_uncover_column(const MunitParameter params[], void* data)
 {
-    int matrix[VSIZE*HSIZE] =
+    char matrix[VSIZE*HSIZE] =
         {
  // sums: 8, 9, 8,11, 7,10, 8, 5, 5
           0, 1, 0, 1, 0, 0, 0, 1, 0,

--- a/tests/test_sparse_matrix_2.c
+++ b/tests/test_sparse_matrix_2.c
@@ -9,7 +9,7 @@ test_make_simple_matrix(const MunitParameter params[], void* data) {
 
   int row_count = 1;
   int col_count = 3;
-  int array[] = {1, 1, 1};
+  char array[] = {1, 1, 1};
 
   list l = create_sparse(row_count, col_count, array);
   munit_assert_not_null(l);
@@ -24,7 +24,7 @@ test_check_details_of_simple_matrix(const MunitParameter params[], void* data) {
 
   int row_count = 1;
   int col_count = 3;
-  int array[] = {1, 1, 1};
+  char array[] = {1, 1, 1};
 
   list l = create_sparse(row_count, col_count, array);
 
@@ -52,7 +52,7 @@ test_check_details_empty_table(const MunitParameter params[], void* data) {
 
   int row_count = 1;
   int col_count = 0;
-  int array[] = {};
+  char array[] = {};
 
   list l = create_sparse(row_count, col_count, array);
   munit_assert_ptr_equal(l, get_right(l));
@@ -68,7 +68,7 @@ test_choose_column_with_min_data(const MunitParameter params[], void* data) {
 
   int row_count = 1;
   int col_count = 3;
-  int array[] = {1, 1, 1};
+  char array[] = {1, 1, 1};
 
   list l = create_sparse(row_count, col_count, array);
 
@@ -87,7 +87,7 @@ test_choose_column_with_min_data_2(const MunitParameter params[], void* data) {
 
   int row_count = 1;
   int col_count = 3;
-  int array[] = {0, 1, 1};
+  char array[] = {0, 1, 1};
 
   list l = create_sparse(row_count, col_count, array);
 
@@ -106,7 +106,7 @@ test_choose_column_with_min_data_empty_table(const MunitParameter params[], void
 
   int row_count = 1;
   int col_count = 0;
-  int array[] = {};
+  char array[] = {};
 
   list l = create_sparse(row_count, col_count, array);
 


### PR DESCRIPTION
At the moment, the `exact_cover` package requires the user to provide the input matrix as a matrix with `dtype=np.int32`. Exact cover problems are naturally described by boolean arrays, so I think it makes more sense to ask the user to supply an array with `dtype=bool`. This pull request changes the requested `dtype` to `bool`. This may break some codes which depend on exact_cover that are set up to give `dtype=np.int32` arrays, but those that use `dtype=DTYPE_FOR_ARRAY` should be fine. `dtype=bool` arrays also use a little less memory. 