### PR TITLE
Use oldest supported numpy for building.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ debug = 'tools.debug:run_debug'
 parse_valgrind = 'tools.debug:parse_valgrind_results'
 
 [build-system]
-requires = ["setuptools", "numpy>=1.20.1", "poetry-core>=1.0.0"]
+requires = ["setuptools", "oldest-supported-numpy", "poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exact_cover"
-version = "1.2.1a0"
+version = "1.2.1"
 description = "Solve exact cover problems"
 readme = "README.md"
 authors = ["Moy Easwaran"]


### PR DESCRIPTION
The new exact-cover 1.2.0 binary wheels don't work on google colab. The reason is that they've been compiled against numpy 1.24 but colab uses  numpy 1.21:
```
RuntimeError                              Traceback (most recent call last)
RuntimeError: module compiled against API version 0x10 but this version of numpy is 0xe.
```
https://numpy.org/devdocs/user/troubleshooting-importerror.html#c-api-incompatibility

I think the package should use "oldest-supported-numpy" supported to fix this. I will see what this does to the CI. This PR is a draft for now.