### PR TITLE
Pin numpy versions for wheel builds

### DIFF
--- a/.github/workflows/poetry-check-sdist-win.yml
+++ b/.github/workflows/poetry-check-sdist-win.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install poetry
         run: |
-            pip install poetry==1.1.11
+            pip install poetry
       - name: make a clean sdist
         run: |
             poetry -V

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install poetry
         run: pip install poetry
       - name: Install requirements
-        run: poetry install
+        run: poetry install --with wheel_builder
       - name: Build package
         run: poetry build -f wheel
       - name: Test package

--- a/.github/workflows/poetry-test.yml
+++ b/.github/workflows/poetry-test.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Install poetry
         run: pip install poetry
       - name: Install requirements
-        run: poetry install
+        run: poetry install --with wheel_builder
       - name: Test package
         run: poetry run test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exact_cover"
-version = "1.2.1"
+version = "1.2.2"
 description = "Solve exact cover problems"
 readme = "README.md"
 authors = ["Moy Easwaran"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,27 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
 numpy = [
-    {version = ">=1.20", python = ">=3.7,<3.10"},
-    {version = ">=1.23", python = ">=3.10"}
+    {version = ">=1.14", python = "==3.7"},
+    {version = ">=1.17", python = "==3.8"},
+    {version = ">=1.19", python = "==3.9"},
+    {version = ">=1.21", python = "==3.10"},
+    {version = ">=1.23", python = "==3.11"},
+    {version = ">=1.24", python = ">=3.12"},
+]
+setuptools = ">=51.1.2"
+
+[tool.poetry.group.wheel_builder]
+optional = true
+
+[tool.poetry.group.wheel_builder.dependencies]
+python = ">=3.7,<4.0"
+numpy = [
+    {version = "==1.14.5", python = "==3.7"},
+    {version = "==1.17.3", python = "==3.8"},
+    {version = "==1.19.3", python = "==3.9"},
+    {version = "==1.21.6", python = "==3.10"},
+    {version = "==1.23.2", python = "==3.11"},
+    {version = ">=1.24.2", python = ">=3.12"},
 ]
 setuptools = ">=51.1.2"
 


### PR DESCRIPTION
This is an attempt to pin the numpy versions when building wheels. It's a rather messy hack, but may work.